### PR TITLE
Fix for Linux AArch64

### DIFF
--- a/tests/test_imagecodecs.py
+++ b/tests/test_imagecodecs.py
@@ -42,6 +42,7 @@ import os.path as osp
 import pathlib
 import re
 import sys
+import platform
 import tempfile
 
 import numpy
@@ -87,6 +88,7 @@ TEST_DIR = osp.dirname(__file__)
 IS_32BIT = sys.maxsize < 2 ** 32
 IS_WIN = sys.platform == 'win32'
 IS_MAC = sys.platform == 'darwin'
+IS_AARCH64 = platform.machine() == 'aarch64'
 IS_PYPY = 'PyPy' in sys.version
 # running on Windows development computer?
 IS_CG = os.environ.get('COMPUTERNAME', '').startswith('CG-')
@@ -119,7 +121,7 @@ def test_module_exist(name):
         pytest.xfail(f'imagecodecs._{name} may be missing')
     elif IS_CI and name == 'jpeg12' and os.environ.get('IMCD_SKIP_JPEG12', 0):
         pytest.xfail(f'imagecodecs._{name} may be missing')
-    elif IS_CI and name == 'jpegxl' and (IS_MAC or IS_32BIT):
+    elif IS_CI and name == 'jpegxl' and (IS_MAC or IS_32BIT or IS_AARCH64):
         pytest.xfail(f'imagecodecs._{name} may be missing')
     assert exists, f'no module named imagecodecs._{name}'
 


### PR DESCRIPTION
Owner: Madhukar
Fix: Fix a test failure on Linux AArch64 failing due to missing jpeg-xl. Simple marked that test as xfail on AArch64. Same already shared with community and they are ready to accept the patch.
Build logs: https://app.circleci.com/pipelines/github/odidev/imagecodecs_build/19/workflows/f2cbb2e1-d891-4a84-a922-ef1df078b54e/jobs/51
Reviewers: Disha and Pruthvi
